### PR TITLE
Fix typo in footer year

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Changed the year in the footer of the main README.md file from 2022 to 2023 to reflect the correct year. This resolves a minor typo in the documentation.